### PR TITLE
add workflow to deploy to crates.io

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,8 @@ name: Lint, Build, and Test implied
 
 on:
   pull_request:
+    branches:
+      - dev
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Test and Coverage
         run: |
-          cargo tarpaulin --out Lcov --target-dir tarpaulin-out/ --skip-clean
+          cargo tarpaulin --out lcov --target-dir tarpaulin-out/ --skip-clean

--- a/.github/workflows/crates.yaml
+++ b/.github/workflows/crates.yaml
@@ -1,0 +1,36 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+name: Release to crates.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout implied code
+        uses: actions/checkout@latest
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Login to crates.io
+        uses: actions-rs/cargo@latest
+        with:
+          command: login
+          args: ${{ secrets.CRATES_TOKEN }}
+
+      - name: Perform a dry run
+        uses: actions-rs/cargo@latest
+        id: dry_run
+        with:
+          command: cargo publish --dry-run
+
+      - name: Publish to crates.io
+        uses: actions-rs/cargo@latest
+        if: steps.dry_run.outcome == 'success' # Only run this step if the dry run was successful
+        with:
+          command: cargo publish


### PR DESCRIPTION
Adds a workflow to deploy to crates.io whenever we want to deploy to crates.io

We should investigate automated versioning, like [cargo-release](https://github.com/crate-ci/cargo-release)

Runs lint/build/test only on PRs into `dev`

I also added the corresponding environment with the secrets in the repo settings